### PR TITLE
Create test_byte_converter

### DIFF
--- a/tests/test_byte_converter
+++ b/tests/test_byte_converter
@@ -1,0 +1,87 @@
+/**
+* @brief 
+* @file test_byte_converter.cpp
+* @author Vishav 
+* @date 2018-10-14
+*/
+
+/* system includes C */
+
+/* system includes C++ */
+#include <gtest/gtest.h>
+#include <list>
+
+
+/* local includes */
+#include "../helpers/byte_converter.h"
+
+
+TEST(TEST_HELPERS, TEST_NUMBERTOBYTES)
+{
+    /*The test data consists of minimum value, max value and a random value. 
+    The first element corresponds to number, second to return value and 3rd to 6th to the
+    raw byte value 
+    */
+    static const std::list<std::tuple<const int, const int, const uint8_t, const uint8_t,const uint8_t, const uint8_t>> _test_data = {
+        { 0, 1, 0,0,0,0},
+        { 4294967295, 4, 255,255,255,255},
+        { 2607, 2, 10,47,0,0},      
+    };
+    /*The fail data corresponds to value greater than (2^32-1) and negative numbers*/
+    static const std::list<std::pair<const uint32_t, const uint32_t>> _test_data_fail = 
+    {
+        {4294967296,4},
+        {-1,1}       
+    };
+
+    for (auto dta_p : _test_data) {
+        uint8_t raw_test[4];
+        memset(raw_test,0,4);
+        int retlen = number_to_bytes(raw_test,std::get<0>(dta_p));
+        ASSERT_GT(retlen, 0);
+        ASSERT_EQ(retlen,std::get<1>(dta_p));
+        ASSERT_EQ(raw_test[0],std::get<2>(dta_p));
+        ASSERT_EQ(raw_test[1],std::get<3>(dta_p));
+        ASSERT_EQ(raw_test[2],std::get<4>(dta_p));
+        ASSERT_EQ(raw_test[3],std::get<5>(dta_p));
+    }
+
+    for(auto dta_p: _test_data_fail)
+    {
+        uint8_t raw_test[4];
+        memset(raw_test,0,4);
+        int retlen = number_to_bytes(raw_test,dta_p.first); 
+        ASSERT_NE(retlen,dta_p.second);
+    }
+}
+
+TEST(TEST_HELPERS, TEST_CHARTOBYTES)
+{
+    /*Test data contains min, max and a random value*/
+    static const std::list<std::pair<const char *, int>> _test_data =
+    {
+        {"0x0",1},
+        {"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",127},
+        {"0x1234567890abcdef",8}    
+    } ;
+    /*Fail Test data contains null value*/
+    static const std::list<std::pair<const char *, int>> _test_data_fail =
+    {
+        {"",0}
+    };
+    for (auto dta_p : _test_data)
+    {
+        uint8_t raw_test[128];
+        memset(raw_test,0,128);
+        int retlen = char_to_bytes(raw_test,dta_p.first);
+        ASSERT_EQ(retlen,dta_p.second);
+    }
+
+   // for (auto dta_p : _test_data_fail)
+   // {
+    //    uint8_t raw_test[128];
+      //  memset(raw_test,0,128);
+       // int retlen = char_to_bytes(raw_test,dta_p.first);
+       // ASSERT_EQ(retlen,dta_p.second);
+   // }
+}


### PR DESCRIPTION
Hi,
Please find attached the unit test file for byte_converter.c I have made the following assumptions and questions:

1. In the function number_to_bytes, I assume that the input number must be from 0 to (2^31-1). Any number negative or greater than this have been considered as fail test cases.
2. In the function char_to_bytes, are we expecting only hexadecimal inputs? If yes, then the input should be verified in the function. In current test cases, I have not considered an input like "rstuvwxyz" but can be done.
3. In the function char_to_bytes, if i enter a null string, I get segmentation fault. Is it expected? or should we do something about it? I have added this as fail case but commented the test, as I was getting segmentation error.
4. Is it required to verify the raw bytes in the function char_to_bytes? I have done it for number_to_bytes but if it is necessary for char_to_bytes, then I will work on it.
Please let me know if there are any questions.

Regards
Vishav