### PR TITLE
Use xcompiler ranlib to build trezor-crypto

### DIFF
--- a/cmake/trezor-crypto.cmake
+++ b/cmake/trezor-crypto.cmake
@@ -20,6 +20,8 @@ ExternalProject_Add(
   TEST_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/install
              -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+             -DCMAKE_RANLIB=${CMAKE_RANLIB}
+             -DCMAKE_AR=${CMAKE_AR}
              -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
              -DCMAKE_EXE_LINKER_FLAGS=${options}
              -DCMAKE_C_COMPILER_WORKS=1

--- a/cmake/zephyr.cmake
+++ b/cmake/zephyr.cmake
@@ -8,17 +8,17 @@ file(GLOB SOURCES "zephyr/*.c")
 
 # keyfile generator
 file(GLOB KEYFILE_GEN_SOURCES "tools/pk_gen.py")
-function(generate_zephyr_keyfile input output)
+function(generate_zephyr_keyfile output)
 add_custom_command(
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/
-    COMMAND ${PYTHON_EXECUTABLE} -m tools.pk_gen --auto --keyfile ${input} > ${output}
+    COMMAND ${PYTHON_EXECUTABLE} -m tools.pk_gen --auto --keyfile ${CMAKE_CURRENT_SOURCE_DIR}/pk.txt > ${output}
     DEPENDS ${KEYFILE_GEN_SOURCES} ${input}
     OUTPUT ${output}
     COMMENT "Generating private key file"
 )
 endfunction()
 set(APP_KEYFILE "${CMAKE_CURRENT_BINARY_DIR}/zephyr/keyfile.c")
-generate_zephyr_keyfile(${CMAKE_CURRENT_SOURCE_DIR}/pk.txt ${APP_KEYFILE})
+generate_zephyr_keyfile( ${APP_KEYFILE})
 
 target_sources(app PRIVATE ${SOURCES} ${APP_KEYFILE})
 zephyr_get_include_directories_for_lang_as_string(       C includes)


### PR DESCRIPTION
- Fixes #92 #103 
