### PR TITLE
integrate tests with valgrind

### DIFF
--- a/examples/tests/src/CMakeLists.txt
+++ b/examples/tests/src/CMakeLists.txt
@@ -104,3 +104,16 @@ add_test(test_crypto test_helpers)
 add_test(test_tx test_tx)
 add_test(test_web3 test_web3)
 add_test(test_sawtooth test_sawtooth)
+
+
+# run tests with valgrind
+find_program(VALGRIND_FOUND valgrind)
+
+SET(TESTS_LIST test_rlp test_data test_abi_compiler test_helpers test_crypto test_tx test_web3 test_sawtooth)
+if(VALGRIND_FOUND)
+    foreach(test_name IN LISTS TESTS_LIST)
+        add_test(${test_name}_valgrind valgrind --leak-check=full --show-leak-kinds=all ${CMAKE_BINARY_DIR}/src/${test_name})
+    endforeach(test_name)
+else(VALGRIND_FOUND)
+    message(WARNING "valgrind executable not found! Disabling memory leaks tests.")
+endif(VALGRIND_FOUND)


### PR DESCRIPTION
Hi @pcppcp ,

what's your opinion on adding valgrind to unit tests?

We use it in some open source projects, they are helpful but the tests take longer as you can see.

The output in this case is:
```
Test project /opt/anyledger/anyledger-wallet/examples/tests/build
      Start  1: test_rlp
 1/16 Test  #1: test_rlp .........................   Passed    0.00 sec
      Start  2: test_data
 2/16 Test  #2: test_data ........................   Passed    0.00 sec
      Start  3: test_abi
 3/16 Test  #3: test_abi .........................   Passed    0.00 sec
      Start  4: test_helpers
 4/16 Test  #4: test_helpers .....................   Passed    0.00 sec
      Start  5: test_crypto
 5/16 Test  #5: test_crypto ......................   Passed    0.00 sec
      Start  6: test_tx
 6/16 Test  #6: test_tx ..........................   Passed    0.00 sec
      Start  7: test_web3
 7/16 Test  #7: test_web3 ........................   Passed    0.00 sec
      Start  8: test_sawtooth
 8/16 Test  #8: test_sawtooth ....................   Passed    0.00 sec
      Start  9: test_rlp_valgrind
 9/16 Test  #9: test_rlp_valgrind ................   Passed    0.90 sec
      Start 10: test_data_valgrind
10/16 Test #10: test_data_valgrind ...............   Passed    0.86 sec
      Start 11: test_abi_compiler_valgrind
11/16 Test #11: test_abi_compiler_valgrind .......   Passed    0.87 sec
      Start 12: test_helpers_valgrind
12/16 Test #12: test_helpers_valgrind ............   Passed    0.92 sec
      Start 13: test_crypto_valgrind
13/16 Test #13: test_crypto_valgrind .............   Passed    1.05 sec
      Start 14: test_tx_valgrind
14/16 Test #14: test_tx_valgrind .................   Passed    0.85 sec
      Start 15: test_web3_valgrind
15/16 Test #15: test_web3_valgrind ...............   Passed    0.93 sec
      Start 16: test_sawtooth_valgrind
16/16 Test #16: test_sawtooth_valgrind ...........   Passed    0.97 sec

100% tests passed, 0 tests failed out of 16
```